### PR TITLE
Implement modern menu browse + item detail UI with customization and editor controls

### DIFF
--- a/src/components/common/Toast.tsx
+++ b/src/components/common/Toast.tsx
@@ -1,0 +1,34 @@
+import clsx from 'classnames';
+
+export interface ToastMessage {
+  id: string;
+  title: string;
+  description?: string;
+  variant?: 'success' | 'error';
+}
+
+interface ToastStackProps {
+  toasts: ToastMessage[];
+}
+
+export function ToastStack({ toasts }: ToastStackProps) {
+  if (!toasts.length) return null;
+  return (
+    <div className="pointer-events-none fixed top-4 left-1/2 z-50 flex w-full max-w-md -translate-x-1/2 flex-col gap-3 px-4" aria-live="polite">
+      {toasts.map((toast) => (
+        <div
+          key={toast.id}
+          className={clsx(
+            'pointer-events-auto rounded-2xl border px-4 py-3 shadow-lg backdrop-blur-sm transition-all',
+            toast.variant === 'error'
+              ? 'border-rose-200 bg-rose-50 text-rose-800'
+              : 'border-emerald-200 bg-white/95 text-slate-900'
+          )}
+        >
+          <p className="text-sm font-semibold">{toast.title}</p>
+          {toast.description && <p className="mt-1 text-xs text-slate-600">{toast.description}</p>}
+        </div>
+      ))}
+    </div>
+  );
+}

--- a/src/components/editor/StyleEditor.tsx
+++ b/src/components/editor/StyleEditor.tsx
@@ -138,6 +138,326 @@ export function StyleEditor({ config, actions }: StyleEditorProps) {
           </div>
         </section>
       </div>
+
+      <div className="grid grid-cols-1 gap-4 lg:grid-cols-2">
+        <section className="rounded-xl border border-slate-200 bg-white p-4 shadow-sm">
+          <h3 className="text-base font-semibold text-slate-900">Menu Display</h3>
+          <p className="text-sm text-slate-600">Control grid density, card visuals, and content visibility.</p>
+          <div className="mt-4 space-y-4 text-sm">
+            <div>
+              <p className="font-semibold text-slate-800">Grid columns</p>
+              <div className="mt-2 flex flex-wrap gap-2">
+                {['1', '2', '3', 'auto'].map((value) => (
+                  <button
+                    key={value}
+                    type="button"
+                    onClick={() => actions.updateMenuDisplay('columns', value as MenuConfig['menuDisplay']['columns'])}
+                    className={`rounded-full border px-3 py-1 ${
+                      config.menuDisplay.columns === value
+                        ? 'border-purple-500 bg-purple-50 text-purple-800'
+                        : 'border-slate-200 bg-white text-slate-700 hover:border-purple-300'
+                    }`}
+                  >
+                    {value === 'auto' ? 'Auto' : `${value} col`}
+                  </button>
+                ))}
+              </div>
+            </div>
+            <div>
+              <p className="font-semibold text-slate-800">Grid spacing</p>
+              <div className="mt-2 flex flex-wrap gap-2">
+                {['compact', 'comfortable', 'spacious'].map((value) => (
+                  <button
+                    key={value}
+                    type="button"
+                    onClick={() => actions.updateMenuDisplay('gap', value as MenuConfig['menuDisplay']['gap'])}
+                    className={`rounded-full border px-3 py-1 capitalize ${
+                      config.menuDisplay.gap === value
+                        ? 'border-purple-500 bg-purple-50 text-purple-800'
+                        : 'border-slate-200 bg-white text-slate-700 hover:border-purple-300'
+                    }`}
+                  >
+                    {value}
+                  </button>
+                ))}
+              </div>
+            </div>
+            <div>
+              <p className="font-semibold text-slate-800">Card style</p>
+              <div className="mt-2 flex flex-wrap gap-2">
+                {['elevated', 'flat', 'outlined', 'minimal'].map((value) => (
+                  <button
+                    key={value}
+                    type="button"
+                    onClick={() => actions.updateMenuDisplay('cardStyle', value as MenuConfig['menuDisplay']['cardStyle'])}
+                    className={`rounded-full border px-3 py-1 capitalize ${
+                      config.menuDisplay.cardStyle === value
+                        ? 'border-purple-500 bg-purple-50 text-purple-800'
+                        : 'border-slate-200 bg-white text-slate-700 hover:border-purple-300'
+                    }`}
+                  >
+                    {value}
+                  </button>
+                ))}
+              </div>
+            </div>
+            <div>
+              <p className="font-semibold text-slate-800">Image layout</p>
+              <div className="mt-2 flex flex-wrap gap-2">
+                {['top', 'left', 'right', 'background'].map((value) => (
+                  <button
+                    key={value}
+                    type="button"
+                    onClick={() => actions.updateMenuDisplay('imagePosition', value as MenuConfig['menuDisplay']['imagePosition'])}
+                    className={`rounded-full border px-3 py-1 capitalize ${
+                      config.menuDisplay.imagePosition === value
+                        ? 'border-purple-500 bg-purple-50 text-purple-800'
+                        : 'border-slate-200 bg-white text-slate-700 hover:border-purple-300'
+                    }`}
+                  >
+                    {value}
+                  </button>
+                ))}
+              </div>
+              <div className="mt-2 flex flex-wrap gap-2">
+                {['square', 'landscape', 'portrait', 'none'].map((value) => (
+                  <button
+                    key={value}
+                    type="button"
+                    onClick={() => actions.updateMenuDisplay('imageAspectRatio', value as MenuConfig['menuDisplay']['imageAspectRatio'])}
+                    className={`rounded-full border px-3 py-1 capitalize ${
+                      config.menuDisplay.imageAspectRatio === value
+                        ? 'border-purple-500 bg-purple-50 text-purple-800'
+                        : 'border-slate-200 bg-white text-slate-700 hover:border-purple-300'
+                    }`}
+                  >
+                    {value}
+                  </button>
+                ))}
+              </div>
+            </div>
+            <div>
+              <p className="font-semibold text-slate-800">Content density</p>
+              <div className="mt-2 flex flex-wrap gap-2">
+                {['compact', 'comfortable', 'spacious'].map((value) => (
+                  <button
+                    key={value}
+                    type="button"
+                    onClick={() => actions.updateMenuDisplay('density', value as MenuConfig['menuDisplay']['density'])}
+                    className={`rounded-full border px-3 py-1 capitalize ${
+                      config.menuDisplay.density === value
+                        ? 'border-purple-500 bg-purple-50 text-purple-800'
+                        : 'border-slate-200 bg-white text-slate-700 hover:border-purple-300'
+                    }`}
+                  >
+                    {value}
+                  </button>
+                ))}
+              </div>
+            </div>
+            <div>
+              <p className="font-semibold text-slate-800">Description display</p>
+              <div className="mt-2 flex flex-wrap gap-2">
+                {['full', 'truncated', 'hidden'].map((value) => (
+                  <button
+                    key={value}
+                    type="button"
+                    onClick={() => actions.updateMenuDisplay('descriptionDisplay', value as MenuConfig['menuDisplay']['descriptionDisplay'])}
+                    className={`rounded-full border px-3 py-1 capitalize ${
+                      config.menuDisplay.descriptionDisplay === value
+                        ? 'border-purple-500 bg-purple-50 text-purple-800'
+                        : 'border-slate-200 bg-white text-slate-700 hover:border-purple-300'
+                    }`}
+                  >
+                    {value}
+                  </button>
+                ))}
+              </div>
+            </div>
+            <div className="grid grid-cols-2 gap-3 text-sm">
+              {[
+                { key: 'showPrepTime', label: 'Show prep time' },
+                { key: 'showDietaryIcons', label: 'Show dietary icons' },
+                { key: 'showCalories', label: 'Show calories' },
+                { key: 'showBadges', label: 'Show badges' }
+              ].map((option) => (
+                <label key={option.key} className="flex items-center gap-2">
+                  <input
+                    type="checkbox"
+                    className="h-4 w-4 rounded border-slate-300 text-purple-600 focus:ring-purple-500"
+                    checked={config.menuDisplay[option.key as keyof MenuConfig['menuDisplay']] as boolean}
+                    onChange={(event) =>
+                      actions.updateMenuDisplay(
+                        option.key as keyof MenuConfig['menuDisplay'],
+                        event.target.checked as MenuConfig['menuDisplay'][keyof MenuConfig['menuDisplay']]
+                      )
+                    }
+                  />
+                  <span className="text-slate-700">{option.label}</span>
+                </label>
+              ))}
+            </div>
+          </div>
+        </section>
+
+        <section className="rounded-xl border border-slate-200 bg-white p-4 shadow-sm">
+          <h3 className="text-base font-semibold text-slate-900">Navigation & Theme</h3>
+          <p className="text-sm text-slate-600">Match category navigation and global brand styling.</p>
+          <div className="mt-4 space-y-4 text-sm">
+            <div>
+              <p className="font-semibold text-slate-800">Navigation layout</p>
+              <div className="mt-2 flex flex-wrap gap-2">
+                {['top', 'sidebar', 'auto'].map((value) => (
+                  <button
+                    key={value}
+                    type="button"
+                    onClick={() => actions.updateNavigationSettings('layout', value as MenuConfig['navigationSettings']['layout'])}
+                    className={`rounded-full border px-3 py-1 capitalize ${
+                      config.navigationSettings.layout === value
+                        ? 'border-purple-500 bg-purple-50 text-purple-800'
+                        : 'border-slate-200 bg-white text-slate-700 hover:border-purple-300'
+                    }`}
+                  >
+                    {value}
+                  </button>
+                ))}
+              </div>
+            </div>
+            <div>
+              <p className="font-semibold text-slate-800">Navigation style</p>
+              <div className="mt-2 flex flex-wrap gap-2">
+                {['filled', 'outlined', 'ghost'].map((value) => (
+                  <button
+                    key={value}
+                    type="button"
+                    onClick={() => actions.updateNavigationSettings('style', value as MenuConfig['navigationSettings']['style'])}
+                    className={`rounded-full border px-3 py-1 capitalize ${
+                      config.navigationSettings.style === value
+                        ? 'border-purple-500 bg-purple-50 text-purple-800'
+                        : 'border-slate-200 bg-white text-slate-700 hover:border-purple-300'
+                    }`}
+                  >
+                    {value}
+                  </button>
+                ))}
+              </div>
+            </div>
+            <div className="grid grid-cols-2 gap-3">
+              {[
+                { key: 'sticky', label: 'Sticky on scroll' },
+                { key: 'showIcons', label: 'Show icons' },
+                { key: 'showCounts', label: 'Show item counts' }
+              ].map((option) => (
+                <label key={option.key} className="flex items-center gap-2">
+                  <input
+                    type="checkbox"
+                    className="h-4 w-4 rounded border-slate-300 text-purple-600 focus:ring-purple-500"
+                    checked={config.navigationSettings[option.key as keyof MenuConfig['navigationSettings']] as boolean}
+                    onChange={(event) =>
+                      actions.updateNavigationSettings(
+                        option.key as keyof MenuConfig['navigationSettings'],
+                        event.target.checked as MenuConfig['navigationSettings'][keyof MenuConfig['navigationSettings']]
+                      )
+                    }
+                  />
+                  <span className="text-slate-700">{option.label}</span>
+                </label>
+              ))}
+            </div>
+            <div>
+              <p className="font-semibold text-slate-800">Primary gradient</p>
+              <div className="mt-2 grid grid-cols-2 gap-2">
+                <input
+                  type="color"
+                  value={config.theme.primaryGradient.start}
+                  onChange={(event) =>
+                    actions.updateThemeSettings('primaryGradient', {
+                      ...config.theme.primaryGradient,
+                      start: event.target.value
+                    })
+                  }
+                  className="h-10 w-full cursor-pointer rounded border border-slate-200"
+                  aria-label="Primary gradient start"
+                />
+                <input
+                  type="color"
+                  value={config.theme.primaryGradient.end}
+                  onChange={(event) =>
+                    actions.updateThemeSettings('primaryGradient', {
+                      ...config.theme.primaryGradient,
+                      end: event.target.value
+                    })
+                  }
+                  className="h-10 w-full cursor-pointer rounded border border-slate-200"
+                  aria-label="Primary gradient end"
+                />
+              </div>
+            </div>
+            <div>
+              <p className="font-semibold text-slate-800">Theme colors</p>
+              <div className="mt-2 grid grid-cols-2 gap-2">
+                <div className="space-y-1">
+                  <label className="text-xs text-slate-500">Background</label>
+                  <input
+                    type="color"
+                    value={config.theme.background}
+                    onChange={(event) => actions.updateThemeSettings('background', event.target.value)}
+                    className="h-10 w-full cursor-pointer rounded border border-slate-200"
+                  />
+                </div>
+                <div className="space-y-1">
+                  <label className="text-xs text-slate-500">Primary text</label>
+                  <input
+                    type="color"
+                    value={config.theme.textPrimary}
+                    onChange={(event) => actions.updateThemeSettings('textPrimary', event.target.value)}
+                    className="h-10 w-full cursor-pointer rounded border border-slate-200"
+                  />
+                </div>
+                <div className="space-y-1">
+                  <label className="text-xs text-slate-500">Secondary text</label>
+                  <input
+                    type="color"
+                    value={config.theme.textSecondary}
+                    onChange={(event) => actions.updateThemeSettings('textSecondary', event.target.value)}
+                    className="h-10 w-full cursor-pointer rounded border border-slate-200"
+                  />
+                </div>
+                <div className="space-y-1">
+                  <label className="text-xs text-slate-500">Card background</label>
+                  <input
+                    type="color"
+                    value={config.theme.cardBackground}
+                    onChange={(event) => actions.updateThemeSettings('cardBackground', event.target.value)}
+                    className="h-10 w-full cursor-pointer rounded border border-slate-200"
+                  />
+                </div>
+                <div className="space-y-1">
+                  <label className="text-xs text-slate-500">Card border</label>
+                  <input
+                    type="color"
+                    value={config.theme.cardBorder}
+                    onChange={(event) => actions.updateThemeSettings('cardBorder', event.target.value)}
+                    className="h-10 w-full cursor-pointer rounded border border-slate-200"
+                  />
+                </div>
+              </div>
+            </div>
+            <div>
+              <p className="font-semibold text-slate-800">Border radius</p>
+              <input
+                type="range"
+                min={0}
+                max={24}
+                value={config.theme.borderRadius}
+                onChange={(event) => actions.updateThemeSettings('borderRadius', Number(event.target.value))}
+                className="mt-2 w-full"
+              />
+              <p className="mt-1 text-xs text-slate-500">{config.theme.borderRadius}px</p>
+            </div>
+          </div>
+        </section>
+      </div>
     </div>
   );
 }

--- a/src/components/menu/Hero.tsx
+++ b/src/components/menu/Hero.tsx
@@ -4,62 +4,60 @@ import { RestaurantInfo } from '../../state/menuConfig';
 
 interface HeroProps {
   info: RestaurantInfo;
+  gradient: { start: string; end: string };
 }
 
-export function Hero({ info }: HeroProps) {
+export function Hero({ info, gradient }: HeroProps) {
   return (
-    <div className="relative overflow-hidden bg-gradient-to-br from-slate-900 via-slate-800 to-slate-900">
-      {/* Background Image with Overlay */}
+    <div
+      className="relative overflow-hidden"
+      style={{ background: `linear-gradient(135deg, ${gradient.start} 0%, ${gradient.end} 100%)` }}
+    >
       <div className="absolute inset-0">
         <img
           src={info.heroImage}
           alt={info.name}
-          className="h-full w-full object-cover opacity-40"
+          className="h-full w-full object-cover opacity-30"
         />
-        <div className="absolute inset-0 bg-gradient-to-t from-slate-900 via-slate-900/80 to-transparent" />
+        <div className="absolute inset-0 bg-gradient-to-t from-slate-950/90 via-slate-900/70 to-transparent" />
       </div>
 
-      {/* Content */}
       <div className="relative mx-auto max-w-7xl px-6 py-16 sm:py-24 lg:px-8">
         <motion.div
           initial={{ opacity: 0, y: 20 }}
           animate={{ opacity: 1, y: 0 }}
           transition={{ duration: 0.6 }}
-          className="max-w-3xl"
+          className="max-w-3xl text-white"
         >
-          {/* Restaurant Name */}
-          <h1 className="text-5xl font-bold tracking-tight text-white sm:text-6xl lg:text-7xl">
+          <h1 className="text-5xl font-bold tracking-tight sm:text-6xl lg:text-7xl">
             {info.name}
           </h1>
 
-          {/* Tagline */}
-          <p className="mt-4 text-xl text-orange-300 sm:text-2xl font-light">
+          <p className="mt-4 text-xl text-white/90 sm:text-2xl font-light">
             {info.tagline}
           </p>
 
-          {/* Cuisine Types */}
           <div className="mt-6 flex flex-wrap gap-2">
             {info.cuisineTypes.map((cuisine) => (
               <span
                 key={cuisine}
-                className="inline-flex items-center rounded-full bg-white/10 backdrop-blur-sm px-4 py-1.5 text-sm font-medium text-white border border-white/20"
+                className="inline-flex items-center rounded-full bg-white/15 px-4 py-1.5 text-sm font-medium text-white backdrop-blur-sm"
               >
                 {cuisine}
               </span>
             ))}
           </div>
 
-          {/* Info Grid */}
           <div className="mt-10 grid gap-4 sm:grid-cols-2 lg:grid-cols-4">
             <motion.div
               initial={{ opacity: 0, y: 10 }}
               animate={{ opacity: 1, y: 0 }}
               transition={{ delay: 0.2, duration: 0.4 }}
-              className="flex items-start gap-3 rounded-lg bg-white/5 backdrop-blur-sm p-4 border border-white/10"
+              className="flex items-start gap-3 rounded-lg bg-white/10 p-4 backdrop-blur-sm"
             >
-              <MapPin className="h-5 w-5 text-orange-400 flex-shrink-0 mt-0.5" />
+              <MapPin className="h-5 w-5 text-white/80 flex-shrink-0 mt-0.5" />
               <div>
-                <p className="text-xs font-medium text-orange-300">Location</p>
+                <p className="text-xs font-medium text-white/70">Location</p>
                 <p className="mt-1 text-sm text-white">{info.address}</p>
               </div>
             </motion.div>
@@ -68,11 +66,11 @@ export function Hero({ info }: HeroProps) {
               initial={{ opacity: 0, y: 10 }}
               animate={{ opacity: 1, y: 0 }}
               transition={{ delay: 0.3, duration: 0.4 }}
-              className="flex items-start gap-3 rounded-lg bg-white/5 backdrop-blur-sm p-4 border border-white/10"
+              className="flex items-start gap-3 rounded-lg bg-white/10 p-4 backdrop-blur-sm"
             >
-              <Clock className="h-5 w-5 text-orange-400 flex-shrink-0 mt-0.5" />
+              <Clock className="h-5 w-5 text-white/80 flex-shrink-0 mt-0.5" />
               <div>
-                <p className="text-xs font-medium text-orange-300">Hours Today</p>
+                <p className="text-xs font-medium text-white/70">Hours Today</p>
                 <p className="mt-1 text-sm text-white">
                   {info.hours[new Date().toLocaleDateString('en-US', { weekday: 'long' })]}
                 </p>
@@ -83,11 +81,11 @@ export function Hero({ info }: HeroProps) {
               initial={{ opacity: 0, y: 10 }}
               animate={{ opacity: 1, y: 0 }}
               transition={{ delay: 0.4, duration: 0.4 }}
-              className="flex items-start gap-3 rounded-lg bg-white/5 backdrop-blur-sm p-4 border border-white/10"
+              className="flex items-start gap-3 rounded-lg bg-white/10 p-4 backdrop-blur-sm"
             >
-              <Phone className="h-5 w-5 text-orange-400 flex-shrink-0 mt-0.5" />
+              <Phone className="h-5 w-5 text-white/80 flex-shrink-0 mt-0.5" />
               <div>
-                <p className="text-xs font-medium text-orange-300">Phone</p>
+                <p className="text-xs font-medium text-white/70">Phone</p>
                 <p className="mt-1 text-sm text-white">{info.phone}</p>
               </div>
             </motion.div>
@@ -96,32 +94,28 @@ export function Hero({ info }: HeroProps) {
               initial={{ opacity: 0, y: 10 }}
               animate={{ opacity: 1, y: 0 }}
               transition={{ delay: 0.5, duration: 0.4 }}
-              className="flex items-start gap-3 rounded-lg bg-white/5 backdrop-blur-sm p-4 border border-white/10"
+              className="flex items-start gap-3 rounded-lg bg-white/10 p-4 backdrop-blur-sm"
             >
-              <Mail className="h-5 w-5 text-orange-400 flex-shrink-0 mt-0.5" />
+              <Mail className="h-5 w-5 text-white/80 flex-shrink-0 mt-0.5" />
               <div>
-                <p className="text-xs font-medium text-orange-300">Email</p>
+                <p className="text-xs font-medium text-white/70">Email</p>
                 <p className="mt-1 text-sm text-white truncate">{info.email}</p>
               </div>
             </motion.div>
           </div>
 
-          {/* Story */}
           {info.story && (
             <motion.p
               initial={{ opacity: 0 }}
               animate={{ opacity: 1 }}
               transition={{ delay: 0.6, duration: 0.4 }}
-              className="mt-8 text-base text-slate-300 leading-relaxed max-w-2xl"
+              className="mt-8 text-base text-white/80 leading-relaxed max-w-2xl"
             >
               {info.story}
             </motion.p>
           )}
         </motion.div>
       </div>
-
-      {/* Decorative gradient */}
-      <div className="absolute bottom-0 left-0 right-0 h-24 bg-gradient-to-t from-white to-transparent" />
     </div>
   );
 }

--- a/src/components/menu/MenuCard.tsx
+++ b/src/components/menu/MenuCard.tsx
@@ -1,0 +1,270 @@
+import { memo } from 'react';
+import clsx from 'classnames';
+import { Clock, Flame, Leaf, WheatOff, Droplet, ShieldCheck, Plus } from 'lucide-react';
+import { MenuConfig, MenuItem } from '../../state/menuConfig';
+
+interface MenuCardProps {
+  item: MenuItem;
+  settings: MenuConfig['menuDisplay'];
+  theme: MenuConfig['theme'];
+  onClick: () => void;
+  onQuickAdd: () => void;
+}
+
+const densityClasses = {
+  compact: {
+    padding: 'p-3',
+    title: 'text-base',
+    description: 'text-xs',
+    button: 'h-11 text-xs',
+  },
+  comfortable: {
+    padding: 'p-4',
+    title: 'text-lg',
+    description: 'text-sm',
+    button: 'h-11 text-sm',
+  },
+  spacious: {
+    padding: 'p-5',
+    title: 'text-xl',
+    description: 'text-[15px]',
+    button: 'h-12 text-sm',
+  }
+};
+
+const badgeStyles: Record<string, string> = {
+  popular: 'bg-gradient-to-r from-purple-500 to-cyan-500 text-white',
+  new: 'bg-red-600 text-white',
+  spicy: 'bg-orange-600 text-white',
+  custom: 'bg-slate-900 text-white'
+};
+
+function getAspectRatio(ratio: MenuConfig['menuDisplay']['imageAspectRatio']) {
+  if (ratio === 'square') return '1 / 1';
+  if (ratio === 'portrait') return '4 / 5';
+  return '16 / 9';
+}
+
+function getDietaryIcon(type: string) {
+  switch (type) {
+    case 'vegan':
+    case 'vegetarian':
+      return Leaf;
+    case 'gluten-free':
+      return WheatOff;
+    case 'dairy-free':
+      return Droplet;
+    case 'nut-free':
+      return ShieldCheck;
+    default:
+      return Leaf;
+  }
+}
+
+export const MenuCard = memo(function MenuCard({ item, settings, theme, onClick, onQuickAdd }: MenuCardProps) {
+  const density = densityClasses[settings.density];
+  const showImage = settings.imageAspectRatio !== 'none' && Boolean(item.image);
+  const cardBase = clsx(
+    'group relative overflow-hidden transition-all duration-200 focus-within:outline focus-within:outline-2 focus-within:outline-offset-2 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2',
+    {
+      'bg-white shadow-[0_2px_8px_rgba(0,0,0,0.08)] hover:shadow-[0_4px_12px_rgba(0,0,0,0.12)] hover:scale-[1.02]':
+        settings.cardStyle === 'elevated',
+      'bg-[#F9FAFB] shadow-none hover:bg-[#F3F4F6]': settings.cardStyle === 'flat',
+      'bg-white border border-[#E5E7EB] shadow-none hover:border-[#D1D5DB] hover:shadow-[0_2px_8px_rgba(0,0,0,0.06)]':
+        settings.cardStyle === 'outlined',
+      'bg-transparent shadow-none border border-transparent hover:bg-black/5': settings.cardStyle === 'minimal'
+    }
+  );
+
+  const cardStyle = {
+    borderRadius: theme.borderRadius,
+    backgroundColor:
+      settings.cardStyle === 'minimal'
+        ? 'transparent'
+        : settings.cardStyle === 'flat'
+        ? '#F9FAFB'
+        : theme.cardBackground,
+    borderColor: settings.cardStyle === 'outlined' ? theme.cardBorder : undefined
+  } as const;
+
+  const content = (
+    <div className={clsx('relative z-10 flex h-full flex-col', density.padding)}>
+      <div className="mb-2 flex flex-wrap gap-1.5">
+        {settings.showBadges &&
+          item.badges?.map((badge) => (
+            <span
+              key={badge.label}
+              className={clsx(
+                'inline-flex items-center gap-1 rounded-full px-2.5 py-1 text-[11px] font-semibold',
+                badgeStyles[badge.type] ?? badgeStyles.custom
+              )}
+              style={badge.color ? { background: badge.color, color: '#fff' } : undefined}
+            >
+              {badge.icon && <span>{badge.icon}</span>}
+              {badge.label}
+            </span>
+          ))}
+      </div>
+      <h3 className={clsx(density.title, 'font-semibold')} style={{ color: theme.textPrimary }}>
+        {item.name}
+      </h3>
+      {settings.descriptionDisplay !== 'hidden' && (
+        <p
+          className={clsx(density.description, 'mt-1 leading-relaxed', settings.descriptionDisplay === 'truncated' && 'line-clamp-2')}
+          style={{ color: theme.textSecondary }}
+        >
+          {item.description}
+        </p>
+      )}
+      {(settings.showDietaryIcons || settings.showPrepTime || settings.showCalories) && (
+        <div className="mt-3 flex flex-wrap items-center gap-3 text-xs text-slate-600">
+          {settings.showDietaryIcons &&
+            item.dietary?.map((tag) => {
+              const Icon = getDietaryIcon(tag.type);
+              return (
+                <span key={tag.label} className="inline-flex items-center gap-1">
+                  <Icon className="h-4 w-4 text-slate-500" aria-hidden="true" />
+                  {tag.label}
+                </span>
+              );
+            })}
+          {settings.showPrepTime && item.prepTime && (
+            <span className="inline-flex items-center gap-1">
+              <Clock className="h-4 w-4 text-slate-500" aria-hidden="true" />
+              {item.prepTime}m
+            </span>
+          )}
+          {settings.showCalories && item.calories && (
+            <span className="inline-flex items-center gap-1">
+              <Flame className="h-4 w-4 text-slate-500" aria-hidden="true" />
+              {item.calories} cal
+            </span>
+          )}
+        </div>
+      )}
+      <div className="mt-4 flex items-center justify-between">
+        <span className="text-lg font-bold" style={{ color: theme.textPrimary }}>
+          {item.price}
+        </span>
+        <button
+          type="button"
+          onClick={(event) => {
+            event.stopPropagation();
+            onQuickAdd();
+          }}
+          className={clsx(
+            'inline-flex items-center gap-2 rounded-lg px-4 text-white shadow-sm transition-all focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2',
+            density.button
+          )}
+          style={{
+            background: `linear-gradient(135deg, ${theme.primaryGradient.start} 0%, ${theme.primaryGradient.end} 100%)`
+          }}
+          aria-label={`Quick add ${item.name}`}
+        >
+          <Plus className="h-4 w-4" aria-hidden="true" />
+          Add
+        </button>
+      </div>
+    </div>
+  );
+
+  if (settings.imagePosition === 'background' && showImage) {
+    return (
+      <article
+        onClick={onClick}
+        className={clsx(cardBase, 'min-h-[240px] cursor-pointer text-white')}
+        style={cardStyle}
+        role="button"
+        tabIndex={0}
+        onKeyDown={(event) => {
+          if (event.key === 'Enter' || event.key === ' ') {
+            event.preventDefault();
+            onClick();
+          }
+        }}
+      >
+        <div className="absolute inset-0">
+          <img src={item.image} alt={item.name} className="h-full w-full object-cover" loading="lazy" />
+          <div className="absolute inset-0 bg-gradient-to-t from-black/70 via-black/30 to-transparent" />
+        </div>
+        <div className={clsx(density.padding, 'relative z-10 flex h-full flex-col justify-end')}>
+          <div className="mb-2 flex flex-wrap gap-1.5">
+            {settings.showBadges &&
+              item.badges?.map((badge) => (
+                <span key={badge.label} className="inline-flex items-center gap-1 rounded-full bg-white/20 px-2.5 py-1 text-[11px] font-semibold">
+                  {badge.label}
+                </span>
+              ))}
+          </div>
+          <h3 className={clsx(density.title, 'font-semibold text-white')}>{item.name}</h3>
+          {settings.descriptionDisplay !== 'hidden' && (
+            <p
+              className={clsx(
+                density.description,
+                'mt-1 text-white/80',
+                settings.descriptionDisplay === 'truncated' && 'line-clamp-2'
+              )}
+            >
+              {item.description}
+            </p>
+          )}
+          <div className="mt-4 flex items-center justify-between">
+            <span className="text-lg font-bold text-white">{item.price}</span>
+            <button
+              type="button"
+              onClick={(event) => {
+                event.stopPropagation();
+                onQuickAdd();
+              }}
+              className={clsx(
+                'inline-flex items-center gap-2 rounded-lg px-4 text-white shadow-sm transition-all',
+                density.button
+              )}
+              style={{
+                background: `linear-gradient(135deg, ${theme.primaryGradient.start} 0%, ${theme.primaryGradient.end} 100%)`
+              }}
+              aria-label={`Quick add ${item.name}`}
+            >
+              <Plus className="h-4 w-4" aria-hidden="true" />
+              Add
+            </button>
+          </div>
+        </div>
+      </article>
+    );
+  }
+
+  return (
+    <article
+      onClick={onClick}
+      className={clsx(cardBase, 'cursor-pointer')}
+      style={cardStyle}
+      role="button"
+      tabIndex={0}
+      onKeyDown={(event) => {
+        if (event.key === 'Enter' || event.key === ' ') {
+          event.preventDefault();
+          onClick();
+        }
+      }}
+    >
+      {settings.imagePosition === 'top' && showImage && (
+        <div className="relative w-full overflow-hidden" style={{ aspectRatio: getAspectRatio(settings.imageAspectRatio) }}>
+          <img src={item.image} alt={item.name} className="h-full w-full object-cover" loading="lazy" />
+        </div>
+      )}
+      {settings.imagePosition !== 'top' ? (
+        <div className={clsx('flex h-full', settings.imagePosition === 'right' && 'flex-row-reverse')}>
+          {showImage && (
+            <div className="relative h-full w-[120px] flex-shrink-0 overflow-hidden">
+              <img src={item.image} alt={item.name} className="h-full w-full object-cover" loading="lazy" />
+            </div>
+          )}
+          {content}
+        </div>
+      ) : (
+        content
+      )}
+    </article>
+  );
+});

--- a/src/components/menu/MenuViewer.tsx
+++ b/src/components/menu/MenuViewer.tsx
@@ -1,164 +1,238 @@
-import { useState } from 'react';
-import { motion, AnimatePresence } from 'framer-motion';
-import { X, ChevronLeft, ChevronRight } from 'lucide-react';
-import { MenuConfig, MenuItem, CategoryConfig } from '../../state/menuConfig';
+import { useMemo, useState } from 'react';
+import { AnimatePresence, motion } from 'framer-motion';
+import { ShoppingBag } from 'lucide-react';
+import { MenuConfig, MenuItem } from '../../state/menuConfig';
 import { Hero } from './Hero';
-import { ChefSpecialCard } from './ChefSpecialCard';
-import { MenuItemCard } from '../preview/MenuItemCard';
+import { MenuCard } from './MenuCard';
 import { ItemDetailModal } from './ItemDetailModal';
+import { ToastMessage, ToastStack } from '../common/Toast';
+import { useCategoryScroll } from '../../hooks/useCategoryScroll';
+import { useCart } from '../../hooks/useCart';
+import { parsePrice } from '../../utils/price';
 
 interface MenuViewerProps {
   config: MenuConfig;
 }
 
-export function MenuViewer({ config }: MenuViewerProps) {
-  const [selectedCategory, setSelectedCategory] = useState(config.categories[0]?.id);
-  const [selectedItem, setSelectedItem] = useState<MenuItem | null>(null);
-  const [layoutColumns, setLayoutColumns] = useState(2);
-  const [cardStyle, setCardStyle] = useState<'compact' | 'feature' | 'list' | 'hero' | 'square' | 'rectangle'>('feature');
+const gapClasses = {
+  compact: 'gap-4',
+  comfortable: 'gap-6',
+  spacious: 'gap-8'
+};
 
-  const category = config.categories.find((cat) => cat.id === selectedCategory) ?? config.categories[0];
+const navSpacingClasses = {
+  compact: 'px-4 py-2',
+  comfortable: 'px-6 py-3',
+  spacious: 'px-7 py-4'
+};
+
+const typographyClasses = {
+  sm: 'text-sm',
+  base: 'text-base',
+  lg: 'text-lg'
+};
+
+const weightClasses = {
+  medium: 'font-medium',
+  semibold: 'font-semibold',
+  bold: 'font-bold'
+};
+
+export function MenuViewer({ config }: MenuViewerProps) {
+  const [selectedItem, setSelectedItem] = useState<MenuItem | null>(null);
+  const [toasts, setToasts] = useState<ToastMessage[]>([]);
+  const { count, addItem } = useCart();
+  const categoryIds = useMemo(() => config.categories.map((category) => category.id), [config.categories]);
+  const { activeId, registerSectionRef, scrollToCategory } = useCategoryScroll({ categoryIds });
+  const navLayout =
+    config.navigationSettings.layout === 'auto'
+      ? config.navigationLayout === 'sidebar'
+        ? 'sidebar'
+        : 'top'
+      : config.navigationSettings.layout;
+
+  const pushToast = (toast: Omit<ToastMessage, 'id'>) => {
+    const id = crypto.randomUUID();
+    setToasts((prev) => [...prev, { ...toast, id }]);
+    window.setTimeout(() => {
+      setToasts((prev) => prev.filter((message) => message.id !== id));
+    }, 3000);
+  };
+
+  const handleQuickAdd = (item: MenuItem) => {
+    const total = parsePrice(item.price);
+    addItem(item, 1, total);
+    pushToast({ title: `${item.name} added`, description: 'Added to your cart.' });
+  };
+
+  const handleAddToCart = (item: MenuItem, quantity: number, totalPrice: number, notes: string) => {
+    addItem(item, quantity, totalPrice);
+    pushToast({
+      title: `${quantity} × ${item.name}`,
+      description: notes ? 'Special instructions saved.' : 'Added to your cart.'
+    });
+  };
+
+  const handleAddPairing = (pairing: MenuItem) => {
+    addItem(pairing, 1, parsePrice(pairing.price));
+    pushToast({ title: `${pairing.name} added`, description: 'Pairing added to your cart.' });
+  };
+
+  const navButtonBase = (isActive: boolean) => {
+    const style = config.navigationSettings.style;
+    const base = `rounded-full transition focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 ${navSpacingClasses[config.navigationSettings.spacing]} ${typographyClasses[config.navigationSettings.typography.size]} ${weightClasses[config.navigationSettings.typography.weight]}`;
+    const textTransform = config.navigationSettings.typography.transform === 'uppercase' ? 'uppercase tracking-wide' : '';
+    if (style === 'outlined') {
+      return `${base} ${textTransform} border ${isActive ? 'border-purple-500 text-purple-700 bg-purple-50' : 'border-slate-200 text-slate-700 hover:border-purple-300'}`;
+    }
+    if (style === 'ghost') {
+      return `${base} ${textTransform} text-slate-700 hover:bg-slate-100 ${isActive ? 'text-purple-700' : ''}`;
+    }
+    return `${base} ${textTransform} ${isActive ? 'text-white shadow-lg' : 'bg-white text-slate-700 border border-slate-200 hover:bg-slate-50'}`;
+  };
+
+  const gridColumnsClass = useMemo(() => {
+    switch (config.menuDisplay.columns) {
+      case '1':
+        return 'grid-cols-1';
+      case '2':
+        return 'grid-cols-1 md:grid-cols-2';
+      case '3':
+        return 'grid-cols-1 md:grid-cols-2 xl:grid-cols-3';
+      default:
+        return 'grid-cols-1';
+    }
+  }, [config.menuDisplay.columns]);
+
+  const navStickyClass =
+    config.navigationSettings.sticky && navLayout !== 'sidebar'
+      ? 'sticky top-20 z-20 bg-slate-50/90 backdrop-blur'
+      : '';
 
   return (
-    <div className="min-h-screen bg-gradient-to-br from-slate-50 via-white to-orange-50/30">
-      {/* Hero Section */}
-      <Hero info={config.restaurantInfo} />
+    <div className="min-h-screen" style={{ background: config.theme.background }}>
+      <a
+        href="#menu-content"
+        className="sr-only focus:not-sr-only focus:absolute focus:left-4 focus:top-4 focus:z-50 focus:rounded-lg focus:bg-white focus:px-4 focus:py-2 focus:text-sm focus:font-semibold"
+      >
+        Skip to menu content
+      </a>
+      <Hero info={config.restaurantInfo} gradient={config.theme.primaryGradient} />
 
-      {/* Main Content */}
-      <div className="mx-auto max-w-7xl px-6 py-12 lg:px-8">
-        {/* Chef's Special Section */}
-        {config.chefSpecials && config.chefSpecials.length > 0 && (
-          <motion.section
-            initial={{ opacity: 0, y: 20 }}
-            animate={{ opacity: 1, y: 0 }}
-            transition={{ delay: 0.2 }}
-            className="mb-16"
+      <ToastStack toasts={toasts} />
+
+      <main className="relative mx-auto flex max-w-7xl flex-col gap-8 px-6 py-10 lg:px-8" id="menu-content">
+        <div className="flex items-center justify-between">
+          <div>
+            <h2 className="text-3xl font-bold" style={{ color: config.theme.textPrimary }}>
+              Browse the menu
+            </h2>
+            <p className="mt-2" style={{ color: config.theme.textSecondary }}>
+              Tap a category to jump or scroll seamlessly.
+            </p>
+          </div>
+          <div className="flex items-center gap-2 rounded-full border border-slate-200 bg-white px-4 py-2 text-sm font-semibold text-slate-700 shadow-sm">
+            <ShoppingBag className="h-4 w-4" aria-hidden="true" />
+            {count} items
+          </div>
+        </div>
+
+        <div className={navLayout === 'sidebar' ? 'flex flex-col gap-8 lg:flex-row' : ''}>
+          <nav
+            className={`flex gap-3 overflow-x-auto pb-2 ${
+              navLayout === 'sidebar'
+                ? `${config.navigationSettings.sticky ? 'lg:sticky lg:top-28' : ''} lg:flex-col lg:overflow-visible lg:pb-0`
+                : navStickyClass
+            }`}
+            aria-label="Menu categories"
           >
-            <div className="mb-8">
-              <h2 className="text-4xl font-bold text-slate-900 mb-2">Chef's Specials</h2>
-              <p className="text-lg text-slate-600">Exclusive culinary experiences curated by our chef</p>
-            </div>
-            <div className="space-y-8">
-              {config.chefSpecials.map((special) => (
-                <ChefSpecialCard key={special.id} special={special} />
-              ))}
-            </div>
-          </motion.section>
-        )}
-
-        {/* Controls */}
-        <motion.div
-          initial={{ opacity: 0 }}
-          animate={{ opacity: 1 }}
-          transition={{ delay: 0.3 }}
-          className="mb-8 flex flex-wrap items-center justify-between gap-4 rounded-xl bg-white p-6 shadow-lg border border-slate-200"
-        >
-          {/* Layout Controls */}
-          <div className="flex items-center gap-3">
-            <span className="text-sm font-semibold text-slate-700">Layout:</span>
-            <div className="flex gap-2">
-              {[1, 2, 3].map((cols) => (
+            {config.categories.map((category) => {
+              const isActive = activeId === category.id;
+              return (
                 <button
-                  key={cols}
-                  onClick={() => setLayoutColumns(cols)}
-                  className={`rounded-lg px-4 py-2 text-sm font-medium transition-all ${
-                    layoutColumns === cols
-                      ? 'bg-orange-600 text-white shadow-md'
-                      : 'bg-slate-100 text-slate-700 hover:bg-slate-200'
-                  }`}
+                  key={category.id}
+                  type="button"
+                  onClick={() => scrollToCategory(category.id)}
+                  className={navButtonBase(isActive)}
+                  style={
+                    config.navigationSettings.style === 'filled' && isActive
+                      ? {
+                          background: `linear-gradient(135deg, ${config.theme.primaryGradient.start} 0%, ${config.theme.primaryGradient.end} 100%)`
+                        }
+                      : undefined
+                  }
+                  aria-current={isActive ? 'true' : undefined}
                 >
-                  {cols} {cols === 1 ? 'Column' : 'Columns'}
+                  {config.navigationSettings.showIcons && category.icon && <span className="mr-2">{category.icon}</span>}
+                  {category.name}
+                  {config.navigationSettings.showCounts && (
+                    <span className="ml-2 text-xs text-slate-500">({category.items.length})</span>
+                  )}
                 </button>
-              ))}
-            </div>
-          </div>
+              );
+            })}
+          </nav>
 
-          {/* Card Style Controls */}
-          <div className="flex items-center gap-3">
-            <span className="text-sm font-semibold text-slate-700">Card Style:</span>
-            <select
-              value={cardStyle}
-              onChange={(e) => setCardStyle(e.target.value as typeof cardStyle)}
-              className="rounded-lg border border-slate-300 bg-white px-4 py-2 text-sm font-medium text-slate-700 shadow-sm transition-all hover:border-orange-400 focus:border-orange-500 focus:outline-none focus:ring-2 focus:ring-orange-500/20"
-            >
-              <option value="compact">Compact</option>
-              <option value="feature">Feature</option>
-              <option value="square">Square</option>
-              <option value="rectangle">Rectangle</option>
-              <option value="list">List</option>
-              <option value="hero">Hero</option>
-            </select>
-          </div>
-        </motion.div>
-
-        {/* Category Navigation */}
-        <motion.nav
-          initial={{ opacity: 0, y: -10 }}
-          animate={{ opacity: 1, y: 0 }}
-          transition={{ delay: 0.4 }}
-          className="mb-8 overflow-x-auto"
-        >
-          <div className="flex gap-3 pb-3">
-            {config.categories.map((cat) => (
-              <button
-                key={cat.id}
-                onClick={() => setSelectedCategory(cat.id)}
-                className={`flex-shrink-0 rounded-full px-6 py-3 text-sm font-semibold transition-all ${
-                  selectedCategory === cat.id
-                    ? 'bg-gradient-to-r from-orange-600 to-amber-600 text-white shadow-lg scale-105'
-                    : 'bg-white text-slate-700 hover:bg-slate-100 border border-slate-200'
-                }`}
+          <div className="flex-1">
+            {config.categories.map((category) => (
+              <motion.section
+                key={category.id}
+                ref={registerSectionRef(category.id)}
+                data-category-id={category.id}
+                className="mb-12 scroll-mt-28"
+                initial={{ opacity: 0, y: 10 }}
+                whileInView={{ opacity: 1, y: 0 }}
+                viewport={{ once: true, amount: 0.2 }}
+                transition={{ duration: 0.3 }}
               >
-                {cat.icon && <span className="mr-2">{cat.icon}</span>}
-                {cat.name}
-              </button>
+                <div className="mb-6 flex items-center justify-between">
+                  <div>
+                    <h3 className="text-2xl font-semibold" style={{ color: config.theme.textPrimary }}>
+                      {category.name}
+                    </h3>
+                    <p className="text-sm" style={{ color: config.theme.textSecondary }}>
+                      {category.items.length} items
+                    </p>
+                  </div>
+                </div>
+                <div
+                  className={`grid ${gapClasses[config.menuDisplay.gap]} ${gridColumnsClass}`}
+                  style={
+                    config.menuDisplay.columns === 'auto'
+                      ? { gridTemplateColumns: 'repeat(auto-fit, minmax(240px, 1fr))' }
+                      : undefined
+                  }
+                >
+                  {category.items.map((item) => (
+                    <MenuCard
+                      key={item.id}
+                      item={item}
+                      settings={config.menuDisplay}
+                      theme={config.theme}
+                      onClick={() => setSelectedItem(item)}
+                      onQuickAdd={() => handleQuickAdd(item)}
+                    />
+                  ))}
+                </div>
+                {category.items.length === 0 && (
+                  <div className="rounded-xl border border-dashed border-slate-200 p-6 text-center text-sm text-slate-500">
+                    No items in this category yet.
+                  </div>
+                )}
+              </motion.section>
             ))}
           </div>
-        </motion.nav>
+        </div>
+      </main>
 
-        {/* Menu Items Grid */}
-        <motion.div
-          key={selectedCategory}
-          initial={{ opacity: 0, y: 20 }}
-          animate={{ opacity: 1, y: 0 }}
-          transition={{ duration: 0.4 }}
-          className="grid gap-6"
-          style={{
-            gridTemplateColumns: `repeat(${layoutColumns}, minmax(0, 1fr))`,
-          }}
-        >
-          {category.items.map((item, index) => (
-            <motion.div
-              key={item.id}
-              initial={{ opacity: 0, y: 20 }}
-              animate={{ opacity: 1, y: 0 }}
-              transition={{ delay: index * 0.05 }}
-            >
-              <MenuItemCard
-                item={item}
-                style={cardStyle}
-                theme={config.colors}
-                shadow={config.shadow}
-                onClick={() => setSelectedItem(item)}
-              />
-            </motion.div>
-          ))}
-        </motion.div>
-
-        {/* Empty State */}
-        {category.items.length === 0 && (
-          <div className="text-center py-16">
-            <p className="text-slate-500 text-lg">No items in this category yet.</p>
-          </div>
-        )}
-      </div>
-
-      {/* Item Detail Modal */}
       <AnimatePresence>
         {selectedItem && (
           <ItemDetailModal
             item={selectedItem}
+            theme={config.theme}
             onClose={() => setSelectedItem(null)}
+            onAddToCart={handleAddToCart}
+            onAddPairing={handleAddPairing}
           />
         )}
       </AnimatePresence>

--- a/src/components/menu/Navigation.tsx
+++ b/src/components/menu/Navigation.tsx
@@ -20,7 +20,7 @@ export function Navigation({ currentView, onViewChange, restaurantName }: Naviga
         <div className="flex h-16 items-center justify-between">
           {/* Logo */}
           <div className="flex items-center gap-3">
-            <div className="rounded-lg bg-gradient-to-br from-orange-600 to-amber-600 p-2">
+            <div className="rounded-lg bg-gradient-to-br from-purple-500 to-cyan-500 p-2">
               <Menu className="h-6 w-6 text-white" />
             </div>
             <div>
@@ -37,7 +37,7 @@ export function Navigation({ currentView, onViewChange, restaurantName }: Naviga
                 onClick={() => onViewChange(id)}
                 className={`relative rounded-lg px-4 py-2 text-sm font-medium transition-all ${
                   currentView === id
-                    ? 'text-orange-600'
+                    ? 'text-purple-600'
                     : 'text-slate-600 hover:text-slate-900 hover:bg-slate-100'
                 }`}
               >
@@ -48,7 +48,7 @@ export function Navigation({ currentView, onViewChange, restaurantName }: Naviga
                 {currentView === id && (
                   <motion.div
                     layoutId="activeTab"
-                    className="absolute bottom-0 left-0 right-0 h-0.5 bg-gradient-to-r from-orange-600 to-amber-600"
+                    className="absolute bottom-0 left-0 right-0 h-0.5 bg-gradient-to-r from-purple-500 to-cyan-500"
                     initial={false}
                     transition={{ type: 'spring', stiffness: 500, damping: 30 }}
                   />

--- a/src/hooks/useCart.ts
+++ b/src/hooks/useCart.ts
@@ -1,0 +1,21 @@
+import { useMemo, useState } from 'react';
+import { MenuItem } from '../state/menuConfig';
+
+export interface CartEntry {
+  id: string;
+  item: MenuItem;
+  quantity: number;
+  totalPrice: number;
+}
+
+export function useCart() {
+  const [items, setItems] = useState<CartEntry[]>([]);
+
+  const addItem = (item: MenuItem, quantity: number, totalPrice: number) => {
+    setItems((prev) => [...prev, { id: crypto.randomUUID(), item, quantity, totalPrice }]);
+  };
+
+  const count = useMemo(() => items.reduce((sum, entry) => sum + entry.quantity, 0), [items]);
+
+  return { items, count, addItem };
+}

--- a/src/hooks/useCategoryScroll.ts
+++ b/src/hooks/useCategoryScroll.ts
@@ -1,0 +1,73 @@
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
+
+interface UseCategoryScrollOptions {
+  categoryIds: string[];
+  offset?: string;
+}
+
+export function useCategoryScroll({ categoryIds, offset = '-30% 0px -60% 0px' }: UseCategoryScrollOptions) {
+  const sectionRefs = useRef(new Map<string, HTMLElement>());
+  const [activeId, setActiveId] = useState<string | null>(categoryIds[0] ?? null);
+  const debounceRef = useRef<number | null>(null);
+
+  const registerSectionRef = useCallback((id: string) => {
+    return (node: HTMLElement | null) => {
+      if (!node) {
+        sectionRefs.current.delete(id);
+        return;
+      }
+      sectionRefs.current.set(id, node);
+    };
+  }, []);
+
+  useEffect(() => {
+    if (!categoryIds.length) return;
+    const observer = new IntersectionObserver(
+      (entries) => {
+        const visible = entries
+          .filter((entry) => entry.isIntersecting)
+          .sort((a, b) => (a.boundingClientRect.top > b.boundingClientRect.top ? 1 : -1));
+
+        if (!visible.length) return;
+        const nextId = visible[0].target.getAttribute('data-category-id');
+        if (!nextId) return;
+        if (debounceRef.current) window.clearTimeout(debounceRef.current);
+        debounceRef.current = window.setTimeout(() => {
+          setActiveId(nextId);
+        }, 150);
+      },
+      { rootMargin: offset, threshold: [0, 0.5, 1] }
+    );
+
+    sectionRefs.current.forEach((node) => observer.observe(node));
+
+    return () => {
+      if (debounceRef.current) window.clearTimeout(debounceRef.current);
+      observer.disconnect();
+    };
+  }, [categoryIds, offset]);
+
+  const scrollToCategory = useCallback((id: string) => {
+    const node = sectionRefs.current.get(id);
+    if (!node) return;
+    const prefersReducedMotion = window.matchMedia('(prefers-reduced-motion: reduce)').matches;
+    node.scrollIntoView({ behavior: prefersReducedMotion ? 'auto' : 'smooth', block: 'start' });
+  }, []);
+
+  const isActive = useCallback(
+    (id: string) => {
+      return activeId === id;
+    },
+    [activeId]
+  );
+
+  return useMemo(
+    () => ({
+      activeId,
+      isActive,
+      registerSectionRef,
+      scrollToCategory
+    }),
+    [activeId, isActive, registerSectionRef, scrollToCategory]
+  );
+}

--- a/src/hooks/useItemCustomization.ts
+++ b/src/hooks/useItemCustomization.ts
@@ -1,0 +1,79 @@
+import { useMemo, useState } from 'react';
+import { MenuItem, ModifierGroup } from '../state/menuConfig';
+
+function buildInitialSelection(groups: ModifierGroup[] = []) {
+  const selected: Record<string, string | string[]> = {};
+  groups.forEach((group) => {
+    const defaultOption = group.options.find((option) => option.default);
+    if (group.required) {
+      selected[group.id] = defaultOption?.id ?? '';
+    } else {
+      selected[group.id] = defaultOption ? [defaultOption.id] : [];
+    }
+  });
+  return selected;
+}
+
+export function useItemCustomization(item: MenuItem) {
+  const [selectedModifiers, setSelectedModifiers] = useState<Record<string, string | string[]>>(() =>
+    buildInitialSelection(item.modifierGroups)
+  );
+  const [quantity, setQuantity] = useState(1);
+  const [specialInstructions, setSpecialInstructions] = useState('');
+  const [errors, setErrors] = useState<Record<string, string>>({});
+
+  const selectOption = (groupId: string, optionId: string) => {
+    setSelectedModifiers((prev) => ({ ...prev, [groupId]: optionId }));
+  };
+
+  const toggleOption = (groupId: string, optionId: string) => {
+    setSelectedModifiers((prev) => {
+      const current = (prev[groupId] as string[]) ?? [];
+      if (current.includes(optionId)) {
+        return { ...prev, [groupId]: current.filter((id) => id !== optionId) };
+      }
+      return { ...prev, [groupId]: [...current, optionId] };
+    });
+  };
+
+  const validate = () => {
+    const nextErrors: Record<string, string> = {};
+    (item.modifierGroups ?? []).forEach((group) => {
+      if (!group.required) return;
+      const selection = selectedModifiers[group.id];
+      if (!selection || (typeof selection === 'string' && selection.length === 0)) {
+        nextErrors[group.id] = `Please select ${group.name.toLowerCase()}.`;
+      }
+    });
+    setErrors(nextErrors);
+    return Object.keys(nextErrors).length === 0;
+  };
+
+  const resetErrors = (groupId?: string) => {
+    if (!groupId) {
+      setErrors({});
+      return;
+    }
+    setErrors((prev) => {
+      const next = { ...prev };
+      delete next[groupId];
+      return next;
+    });
+  };
+
+  const modifiers = useMemo(() => item.modifierGroups ?? [], [item.modifierGroups]);
+
+  return {
+    selectedModifiers,
+    quantity,
+    specialInstructions,
+    errors,
+    modifiers,
+    setQuantity,
+    setSpecialInstructions,
+    selectOption,
+    toggleOption,
+    validate,
+    resetErrors
+  };
+}

--- a/src/hooks/useMenuConfig.ts
+++ b/src/hooks/useMenuConfig.ts
@@ -26,6 +26,12 @@ export interface MenuConfigActions {
   setDefaultStyle: (style: CardStyle) => void;
   setDefaultColumns: (columns: number) => void;
   toggleBadge: (categoryId: string, itemId: string, type: 'tags' | 'allergens', label: string) => void;
+  updateMenuDisplay: <K extends keyof MenuConfig['menuDisplay']>(key: K, value: MenuConfig['menuDisplay'][K]) => void;
+  updateNavigationSettings: <K extends keyof MenuConfig['navigationSettings']>(
+    key: K,
+    value: MenuConfig['navigationSettings'][K]
+  ) => void;
+  updateThemeSettings: <K extends keyof MenuConfig['theme']>(key: K, value: MenuConfig['theme'][K]) => void;
 }
 
 export function useMenuConfig(): [MenuConfig, MenuConfigActions] {
@@ -84,13 +90,21 @@ export function useMenuConfig(): [MenuConfig, MenuConfigActions] {
       updateNavigationLayout: (layout: NavigationLayout) => {
         setConfig((prev) => ({
           ...prev,
-          navigationLayout: layout
+          navigationLayout: layout,
+          navigationSettings: {
+            ...prev.navigationSettings,
+            layout: layout === 'sidebar' ? 'sidebar' : 'top'
+          }
         }));
       },
       updateNavigationStyle: (style: NavigationStyle) => {
         setConfig((prev) => ({
           ...prev,
-          navigationStyle: style
+          navigationStyle: style,
+          navigationSettings: {
+            ...prev.navigationSettings,
+            style
+          }
         }));
       },
       updateThemeColor: (key, value) => {
@@ -138,6 +152,33 @@ export function useMenuConfig(): [MenuConfig, MenuConfigActions] {
               })
             };
           })
+        }));
+      },
+      updateMenuDisplay: (key, value) => {
+        setConfig((prev) => ({
+          ...prev,
+          menuDisplay: {
+            ...prev.menuDisplay,
+            [key]: value
+          }
+        }));
+      },
+      updateNavigationSettings: (key, value) => {
+        setConfig((prev) => ({
+          ...prev,
+          navigationSettings: {
+            ...prev.navigationSettings,
+            [key]: value
+          }
+        }));
+      },
+      updateThemeSettings: (key, value) => {
+        setConfig((prev) => ({
+          ...prev,
+          theme: {
+            ...prev.theme,
+            [key]: value
+          }
         }));
       }
     }),

--- a/src/index.css
+++ b/src/index.css
@@ -11,6 +11,10 @@ body {
   font-family: 'Inter', system-ui, -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif;
 }
 
+html {
+  scroll-behavior: smooth;
+}
+
 .scrollbar-thin {
   scrollbar-width: thin;
 }
@@ -26,4 +30,31 @@ body {
 .scrollbar-thin::-webkit-scrollbar-thumb {
   background-color: rgba(148, 163, 184, 0.6);
   border-radius: 9999px;
+}
+
+@keyframes pricePulse {
+  0% {
+    transform: scale(1);
+  }
+  50% {
+    transform: scale(1.06);
+  }
+  100% {
+    transform: scale(1);
+  }
+}
+
+.price-pulse {
+  display: inline-block;
+  animation: pricePulse 300ms ease;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  html {
+    scroll-behavior: auto;
+  }
+
+  .price-pulse {
+    animation: none;
+  }
 }

--- a/src/state/menuConfig.ts
+++ b/src/state/menuConfig.ts
@@ -2,10 +2,53 @@ export type NavigationLayout = 'horizontal' | 'sidebar';
 export type NavigationStyle = 'filled' | 'outlined' | 'ghost';
 export type CardStyle = 'compact' | 'feature' | 'list' | 'hero' | 'square' | 'rectangle';
 export type ShadowLevel = 'off' | 'subtle' | 'medium' | 'strong';
+export type GridColumns = '1' | '2' | '3' | 'auto';
+export type GridGap = 'compact' | 'comfortable' | 'spacious';
+export type CardStyleVariant = 'elevated' | 'flat' | 'outlined' | 'minimal';
+export type ImageAspectRatio = 'square' | 'landscape' | 'portrait' | 'none';
+export type ImagePosition = 'top' | 'left' | 'right' | 'background';
+export type DescriptionDisplay = 'full' | 'truncated' | 'hidden';
+export type ContentDensity = 'compact' | 'comfortable' | 'spacious';
+export type NavigationLayoutSetting = 'top' | 'sidebar' | 'auto';
+export type NavigationSpacing = 'compact' | 'comfortable' | 'spacious';
+export type TypographyTransform = 'none' | 'uppercase';
+export type TypographyWeight = 'medium' | 'semibold' | 'bold';
+export type TypographySize = 'sm' | 'base' | 'lg';
+export type ShadowElevation = 'none' | 'low' | 'medium' | 'high';
 
 export interface FoodPairing {
   name: string;
   description: string;
+}
+
+export interface MenuBadge {
+  type: 'popular' | 'new' | 'spicy' | 'custom';
+  label: string;
+  color?: string;
+  icon?: string;
+}
+
+export interface DietaryTag {
+  type: 'vegan' | 'vegetarian' | 'gluten-free' | 'dairy-free' | 'nut-free';
+  label: string;
+  icon?: string;
+}
+
+export interface ModifierOption {
+  id: string;
+  name: string;
+  description?: string;
+  price: number;
+  default?: boolean;
+}
+
+export interface ModifierGroup {
+  id: string;
+  name: string;
+  required: boolean;
+  min?: number;
+  max?: number;
+  options: ModifierOption[];
 }
 
 export interface MenuItem {
@@ -20,6 +63,12 @@ export interface MenuItem {
   foodPairings?: FoodPairing[];
   chefNotes?: string;
   ingredients?: string[];
+  prepTime?: number;
+  calories?: number;
+  badges?: MenuBadge[];
+  dietary?: DietaryTag[];
+  modifierGroups?: ModifierGroup[];
+  pairings?: MenuItem[];
   isSample?: boolean;
   isFeatured?: boolean;
   isChefFavorite?: boolean;
@@ -70,6 +119,45 @@ export interface ThemeConfig {
   accent: string;
 }
 
+export interface MenuDisplaySettings {
+  columns: GridColumns;
+  gap: GridGap;
+  cardStyle: CardStyleVariant;
+  imageAspectRatio: ImageAspectRatio;
+  imagePosition: ImagePosition;
+  density: ContentDensity;
+  descriptionDisplay: DescriptionDisplay;
+  showPrepTime: boolean;
+  showDietaryIcons: boolean;
+  showCalories: boolean;
+  showBadges: boolean;
+}
+
+export interface NavigationSettings {
+  layout: NavigationLayoutSetting;
+  style: NavigationStyle;
+  sticky: boolean;
+  showIcons: boolean;
+  showCounts: boolean;
+  spacing: NavigationSpacing;
+  typography: {
+    size: TypographySize;
+    weight: TypographyWeight;
+    transform: TypographyTransform;
+  };
+}
+
+export interface ThemeSettings {
+  primaryGradient: { start: string; end: string };
+  background: string;
+  textPrimary: string;
+  textSecondary: string;
+  cardBackground: string;
+  cardBorder: string;
+  borderRadius: number;
+  shadowElevation: ShadowElevation;
+}
+
 export interface MenuConfig {
   navigationLayout: NavigationLayout;
   navigationStyle: NavigationStyle;
@@ -77,10 +165,40 @@ export interface MenuConfig {
   columnsDefault: number;
   shadow: ShadowLevel;
   colors: ThemeConfig;
+  menuDisplay: MenuDisplaySettings;
+  navigationSettings: NavigationSettings;
+  theme: ThemeSettings;
   categories: CategoryConfig[];
   restaurantInfo: RestaurantInfo;
   chefSpecials?: ChefSpecial[];
 }
+
+const defaultSizeModifiers: ModifierGroup[] = [
+  {
+    id: 'size',
+    name: 'Choose Your Size',
+    required: true,
+    options: [
+      { id: 'small', name: 'Small Plate (2 pieces)', price: 8.99 },
+      { id: 'regular', name: 'Regular (3 pieces)', price: 12.99, default: true },
+      { id: 'large', name: 'Large Platter (6 pieces)', price: 22.99 }
+    ]
+  }
+];
+
+const defaultExtraModifiers: ModifierGroup[] = [
+  {
+    id: 'extras',
+    name: 'Add Extras',
+    required: false,
+    max: 3,
+    options: [
+      { id: 'olive-oil', name: 'Extra Virgin Olive Oil', price: 1.5 },
+      { id: 'burrata', name: 'Burrata Cheese', price: 4 },
+      { id: 'prosciutto', name: 'Prosciutto', price: 5 }
+    ]
+  }
+];
 
 const premiumMenuItems: MenuItem[] = [
   {
@@ -96,6 +214,43 @@ const premiumMenuItems: MenuItem[] = [
     ],
     tags: ['Vegetarian', 'Chef\'s Favorite'],
     allergens: ['Gluten', 'Dairy'],
+    prepTime: 12,
+    calories: 620,
+    badges: [
+      { type: 'popular', label: 'Popular' },
+      { type: 'new', label: 'New' }
+    ],
+    dietary: [{ type: 'vegetarian', label: 'Vegetarian' }],
+    modifierGroups: [...defaultSizeModifiers, ...defaultExtraModifiers],
+    pairings: [
+      {
+        id: 'caprese-salad',
+        name: 'Caprese Salad',
+        description: 'Heirloom tomatoes, basil, buffalo mozzarella.',
+        price: '$8.99',
+        image: 'https://images.unsplash.com/photo-1540189549336-e6e99c3679fe?auto=format&fit=crop&w=400&q=80',
+        tags: ['Vegetarian'],
+        allergens: ['Dairy']
+      },
+      {
+        id: 'arancini-balls',
+        name: 'Arancini Balls',
+        description: 'Crispy saffron risotto, truffle aioli.',
+        price: '$7.99',
+        image: 'https://images.unsplash.com/photo-1604908176997-125f25cc6f3d?auto=format&fit=crop&w=400&q=80',
+        tags: ['Popular'],
+        allergens: ['Dairy', 'Gluten']
+      },
+      {
+        id: 'pinot-grigio',
+        name: 'Pinot Grigio',
+        description: 'Crisp, floral white wine pairing.',
+        price: '$12.00',
+        image: 'https://images.unsplash.com/photo-1470337458703-46ad1756a187?auto=format&fit=crop&w=400&q=80',
+        tags: ['Wine'],
+        allergens: []
+      }
+    ],
     ingredients: ['Pizza dough', 'Black truffle oil', 'Shiitake mushrooms', 'Oyster mushrooms', 'Mozzarella', 'Fresh thyme', 'Parmesan'],
     foodPairings: [
       { name: 'Pinot Noir', description: 'Earthy notes complement the truffle' },
@@ -119,6 +274,11 @@ const premiumMenuItems: MenuItem[] = [
     ],
     tags: ['Spicy', 'Popular'],
     allergens: ['Shellfish', 'Gluten'],
+    prepTime: 8,
+    calories: 480,
+    badges: [{ type: 'popular', label: 'Popular' }, { type: 'spicy', label: 'Spicy' }],
+    dietary: [{ type: 'dairy-free', label: 'Dairy-Free' }],
+    modifierGroups: [...defaultSizeModifiers, ...defaultExtraModifiers],
     ingredients: ['Fresh squid', 'Semolina flour', 'San Marzano tomatoes', 'Calabrian chili', 'Lemon', 'Garlic aioli'],
     foodPairings: [
       { name: 'Prosecco', description: 'Crisp bubbles cut through the richness' },
@@ -144,6 +304,10 @@ const mainCourseItems: MenuItem[] = [
     ],
     tags: ['Gluten Free', 'Healthy'],
     allergens: ['Fish'],
+    prepTime: 18,
+    calories: 540,
+    badges: [{ type: 'popular', label: 'Popular' }],
+    dietary: [{ type: 'gluten-free', label: 'Gluten-Free' }],
     ingredients: ['Atlantic salmon', 'Tri-color quinoa', 'Asparagus', 'Cherry tomatoes', 'Lemon herb butter'],
     foodPairings: [
       { name: 'Chardonnay', description: 'Buttery richness enhances the salmon' },
@@ -166,6 +330,10 @@ const mainCourseItems: MenuItem[] = [
     ],
     tags: ['Signature', 'Popular'],
     allergens: ['Gluten', 'Dairy'],
+    prepTime: 15,
+    calories: 780,
+    badges: [{ type: 'popular', label: 'Popular' }],
+    dietary: [{ type: 'nut-free', label: 'Nut-Free' }],
     ingredients: ['Wagyu beef', 'Brioche bun', '18-month aged cheddar', 'House bacon jam', 'Arugula', 'Truffle aioli'],
     foodPairings: [
       { name: 'Cabernet Sauvignon', description: 'Bold tannins match the rich beef' },
@@ -190,6 +358,10 @@ const mainCourseItems: MenuItem[] = [
     ],
     tags: ['Premium', 'Chef\'s Favorite'],
     allergens: ['Shellfish', 'Gluten', 'Dairy'],
+    prepTime: 16,
+    calories: 640,
+    badges: [{ type: 'new', label: 'New' }],
+    dietary: [{ type: 'dairy-free', label: 'Dairy-Free' }],
     ingredients: ['Fresh pasta', 'Maine lobster', 'Tomato cream sauce', 'Vodka', 'Fresh basil', 'Parmesan'],
     foodPairings: [
       { name: 'Pinot Grigio', description: 'Light and crisp to complement shellfish' },
@@ -360,6 +532,42 @@ export const defaultMenuConfig: MenuConfig = {
     text: '#0f172a',
     accent: '#f97316'
   },
+  menuDisplay: {
+    columns: 'auto',
+    gap: 'comfortable',
+    cardStyle: 'elevated',
+    imageAspectRatio: 'landscape',
+    imagePosition: 'top',
+    density: 'comfortable',
+    descriptionDisplay: 'truncated',
+    showPrepTime: true,
+    showDietaryIcons: true,
+    showCalories: true,
+    showBadges: true
+  },
+  navigationSettings: {
+    layout: 'auto',
+    style: 'filled',
+    sticky: true,
+    showIcons: true,
+    showCounts: true,
+    spacing: 'comfortable',
+    typography: {
+      size: 'base',
+      weight: 'semibold',
+      transform: 'none'
+    }
+  },
+  theme: {
+    primaryGradient: { start: '#A855F7', end: '#06B6D4' },
+    background: '#F8FAFC',
+    textPrimary: '#111827',
+    textSecondary: '#6B7280',
+    cardBackground: '#FFFFFF',
+    cardBorder: '#E5E7EB',
+    borderRadius: 12,
+    shadowElevation: 'medium'
+  },
   restaurantInfo,
   chefSpecials,
   categories: [
@@ -410,7 +618,10 @@ export function createEmptyItem(id: string): MenuItem {
     description: '',
     price: '$0.00',
     tags: [],
-    allergens: []
+    allergens: [],
+    badges: [],
+    dietary: [],
+    modifierGroups: []
   };
 }
 

--- a/src/utils/price.ts
+++ b/src/utils/price.ts
@@ -1,0 +1,8 @@
+export function parsePrice(value: string) {
+  const parsed = Number(value.replace(/[^\d.]/g, ''));
+  return Number.isFinite(parsed) ? parsed : 0;
+}
+
+export function formatPrice(value: number) {
+  return `$${value.toFixed(2)}`;
+}


### PR DESCRIPTION
### Motivation
- Deliver a production-ready Modern Table dine-in QR ordering UI focused on menu browsing and item detail experience (category nav + responsive grid + full item modal with modifiers). 
- Provide restaurant operators fine-grained display, navigation and theme customization so the preview/editor can match the operator controls described in the spec. 
- Improve accessibility, keyboard support, and polished interactions (animations, toasts, lightbox, reduced-motion handling) to reach agency-grade UX. 

### Description
- Expanded state and types in `src/state/menuConfig.ts` to include `menuDisplay`, `navigationSettings`, `theme`, modifier groups, badges, dietary tags, pairings and sensible defaults for layout, gaps, densities and purple→cyan gradient theme. 
- Added a modern card component `src/components/menu/MenuCard.tsx` and rewired the preview viewer to `src/components/menu/MenuViewer.tsx` with scroll-synced category nav, responsive grid column modes (`1|2|3|auto`), gap presets, quick-add, toasts and cart count. 
- Implemented the full item detail experience in `src/components/menu/ItemDetailModal.tsx` with modifier groups, validation, quantity selector, live price calculation (`src/utils/price.ts`), lightbox image preview, perfect-pairings add, animations and ARIA/keyboard affordances. 
- Added supporting hooks and UI: `useCategoryScroll` (scroll-sync), `useItemCustomization` (modifier state + validation), `useCart`, `ToastStack` component, price pulse animation in `src/index.css`, and editor controls in `src/components/editor/StyleEditor.tsx` to manage the new display/navigation/theme settings. 

### Testing
- Attempted to launch the dev server with `npm run dev -- --host 0.0.0.0 --port 4173`, which failed due to `vite: Permission denied` in this environment. 
- Attempted to start Vite directly with `node node_modules/vite/bin/vite.js --host 0.0.0.0 --port 4173`, which failed due to a missing optional Rollup native dependency (`@rollup/rollup-linux-x64-gnu`) reported by Rollup. 
- No automated unit or integration tests were executed in the current environment; changes were committed (`git commit`) after local edits and additions completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_697d77786f28832f978dedcef7104e28)